### PR TITLE
Make transitions smoother by adjusting the border-radius values

### DIFF
--- a/spotlight.css
+++ b/spotlight.css
@@ -14,18 +14,19 @@ Developed by Alvaro Montoro. More info: https://github.com/alvaromontoro/spotlig
 }
 #spjs-frame #spjs-spot {
   position: absolute;
-  border-radius: 99%;
+  border-radius: 100%;
   box-shadow: inset 0 0 8px 0;
-  border: 200vmax solid;
+  border: 100vmax solid;
   color: rgba(0, 0, 0, 0.5);
   transition: all 0.5s;
   transform: translate(-50%, -50%);
 }
 #spjs-frame #spjs-spot.spjs-square, #spjs-frame #spjs-spot.spjs-step-square {
   border-radius: 5px;
+  border-radius: calc(100vmax + 5px);
 }
 #spjs-frame #spjs-spot.spjs-step-round {
-  border-radius: 99%;
+  border-radius: 100%;
 }
 #spjs-frame #spjs-spot #spjs-text {
   position: absolute;

--- a/spotlight.scss
+++ b/spotlight.scss
@@ -13,18 +13,19 @@ Developed by Alvaro Montoro. More info: https://github.com/alvaromontoro/spotlig
   background: rgba(0,0,0,0.01);
   #spjs-spot {
     position: absolute;
-    border-radius: 99%;
+    border-radius: 100%;
     box-shadow: inset 0 0 8px 0;
-    border: 200vmax solid;
+    border: 100vmax solid;
     color: rgba(0,0,0,0.5);
     transition: all 0.5s;
     transform: translate(-50%, -50%);
     &.spjs-square,
     &.spjs-step-square {
       border-radius: 5px;
+      border-radius: calc(100vmax + 5px);
     }
     &.spjs-step-round {
-      border-radius: 99%;
+      border-radius: 100%;
     }
     #spjs-text {
       position: absolute;


### PR DESCRIPTION
The transitions are not as smooth as I would have liked, but they are far better than the sudden change of shape from before.

I also changed the border-radius from 99% to 100% as by using borders, that _hack_ is not really needed anymore.