### PR TITLE
Allow to set up the data attributes in the options

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,18 @@ For more examples on how to start, check the repository demos.
 | shape | square\|round | String that indicates the shape of the spotlight: squared or round/elliptical. Default value: "round". |
 | skip | Boolean | Indicates if the link to skip the instructions will be displayed. Default: true |
 | skipText | String | Specifies the text of the link to skip instructions. Default: "Skip presentation" |
-| steps | Array | List with the selectors of the elements to be highlighted as part of the instructions. This field has no default value. **Either this parameter of `init` must be specified when starting SpotlightJS.** |
+| steps | Array | List with objects that will contain ID, text, and shape of the element to be highlighted (see more below). This field has no default value. **Either this parameter of `init` must be specified when starting SpotlightJS.** |
+
+The structure of the steps list will be as follows:
+
+    [
+      {
+        selector: "selector-of-the-element-to-be-highglighted-(mandatory)",
+        text: "text-to-be-displayed-(optional)",
+        shape: "shape-of-the-element-(optional)"
+      },
+      ...
+    ]
 
 ## API methods
 

--- a/demos/spotlight.js
+++ b/demos/spotlight.js
@@ -27,7 +27,7 @@ var SpotlightJS = function SpotlightJS(options) {
       if (!isNaN(step) && step > -1 && step < _this.steps.length) {
         _this.spot.classList.remove("spjs-step-" + _this.current, "spjs-step-square", "spjs-step-round");
         _this.current = step;
-        var el = document.querySelector(_this.steps[step]);
+        var el = document.querySelector(_this.steps[step].selector);
         if (el) {
           var elRect = el.getBoundingClientRect();
           _this.spot.style.width = elRect.width + 20 + "px";
@@ -35,9 +35,9 @@ var SpotlightJS = function SpotlightJS(options) {
           _this.spot.style.top = (elRect.top + elRect.height/2) + "px";
           _this.spot.style.left = (elRect.left + elRect.width/2) + "px";
           _this.spot.classList.add("spjs-step-" + step); // to allow user styling specific to each step
-          _this.textContent.textContent = el.dataset.spText;
+          _this.textContent.textContent = _this.steps[step].text;
           if (_this.previousButton) _this.previousButton.style.display = _this.current == 0 ? "none" : "inline-block";
-          if (el.dataset.spShape) _this.spot.classList.add("spjs-step-" + el.dataset.spShape);
+          if (_this.steps[step].shape) _this.spot.classList.add("spjs-step-" + _this.steps[step].shape);
         }
       }
     }
@@ -72,7 +72,7 @@ var SpotlightJS = function SpotlightJS(options) {
 
   // returns the selector for the element that is being highlighted
   this.currentElementSelector = function () {
-    return _this.steps[_this.current];
+    return _this.steps[_this.current].selector;
   };
 
   // returns the DOM element that is being highlighted at the moment
@@ -82,7 +82,7 @@ var SpotlightJS = function SpotlightJS(options) {
 
   // returns the text associated to the current step
   this.getText = function () {
-    return _this.currentElement().dataset.spText;
+    return _this.steps[_this.current].text;
   };
 
   // returns the current step (1..n)
@@ -157,7 +157,12 @@ var SpotlightJS = function SpotlightJS(options) {
   if (this.init != "" && !this.hasSteps()) {
     var el = this.init;
     while (el) {
-      this.steps.push(el);
+      var elObj = document.querySelector(el);
+      this.steps.push({
+        selector: el,
+        text: elObj.dataset.spText || "",
+        shape: elObj.dataset.spShape || ""
+      });
       el = document.querySelector(el).dataset.spNext;
     }
   }

--- a/spotlight.babel
+++ b/spotlight.babel
@@ -44,7 +44,12 @@ class SpotlightJS {
     if (this.init != "" && !this.hasSteps()) {
       let el = this.init;
       while (el) {
-        this.steps.push(el);
+        let elObj = document.querySelector(el);
+        this.steps.push({
+          selector: el,
+          text: elObj.dataset.spText || "",
+          shape: elObj.dataset.spShape || ""
+        });
         el = document.querySelector(el).dataset.spNext;
       }
     }
@@ -126,7 +131,7 @@ class SpotlightJS {
       if (!isNaN(step) && step > -1 && step < this.steps.length) {
         this.spot.classList.remove("spjs-step-"+this.current, "spjs-step-square", "spjs-step-round");
         this.current = step;
-        let el = document.querySelector(this.steps[step]);
+        let el = document.querySelector(this.steps[step].selector);
         if (el) {
           let elRect = el.getBoundingClientRect();
           this.spot.style.width = (elRect.width + 20) + "px";
@@ -134,11 +139,11 @@ class SpotlightJS {
           this.spot.style.top = (elRect.top + elRect.height/2) + "px";
           this.spot.style.left = (elRect.left + elRect.width/2) + "px";
           this.spot.classList.add("spjs-step-" + step); // to allow user styling specific to each step
-          this.textContent.textContent = el.dataset.spText;
+          this.textContent.textContent = this.steps[step].text;
           if (this.previousButton)
             this.previousButton.style.display = this.current == 0 ? "none" : "inline-block";
-          if (el.dataset.spShape)
-            this.spot.classList.add("spjs-step-" + el.dataset.spShape);
+          if (this.steps[step].shape)
+            this.spot.classList.add("spjs-step-" + this.steps[step].shape);
         }
       }
     }
@@ -170,13 +175,13 @@ class SpotlightJS {
   hasSteps = () => (this.init != "" && this.steps.length > 0);
 
   /** returns the identifier of the current element */
-  currentElementSelector = () => this.steps[this.current];
+  currentElementSelector = () => this.steps[this.current].selector;
 
   /** returns the currently highlighted element */
   currentElement = () => document.querySelector(this.currentElementSelector());
 
   /** returns the text of the currently highlighted element */
-  getText = () => this.currentElement().dataset.spText;
+  getText = () => this.steps[this.current].text;
 
   /** returns the current step */
   getStep = () => this.current + 1;


### PR DESCRIPTION
- Modify the steps so it can be an array of objects instead of array of strings.
- Update the code to read from steps instead of from the elements ("shadow DOM")
- Include the change in the README.md file

Issue #10